### PR TITLE
Add resource option and TypeScript types

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,9 +35,9 @@ const writeStream = stackdriver.createWriteStream({
 
 #### credentials
 
-Type: `String` *(required)*
+Type: `String` *(optional)*
 
-Full path to the JSON file containing the Google Service Credentials.
+Full path to the JSON file containing the Google Service Credentials. Defaults to the GOOGLE_APPLICATION_CREDENTIALS environment variable. At least one has to be available.
 
 #### projectId
 
@@ -45,3 +45,14 @@ Type: `String` *(required)*
 
 The name of the project.
 
+#### logName
+
+Type: `String` *(optional)*
+
+The name of the log. Defaults to `"pino_log"`.
+
+#### resource
+
+Type: `{ type: String, labels: Object }` *(optional)*
+
+The resource to send logs to. Defaults to `{ type: "global" }`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A transport for pino that sends messages to Google Stackdriver Logging",
   "homepage": "https://github.com/ovhemert/pino-stackdriver",
   "main": "src/index.js",
+  "types": "pino-stackdriver.d.ts",
   "scripts": {
     "dev:cli": "node ./test/debug.js | node ./src/cli.js",
     "lint": "standard",

--- a/pino-stackdriver.d.ts
+++ b/pino-stackdriver.d.ts
@@ -1,0 +1,39 @@
+declare module "pino-stackdriver" {
+  namespace PinoStackdriver {
+    interface Options {
+      /**
+       * Full path to the JSON file containing the Google Service Credentials.
+       * Required if GOOGLE_APPLICATION_CREDENTIALS is not set as an environment variable.
+       */
+      credentials?: string;
+
+      /**
+       * The name of the project.
+       */
+      projectId: string;
+
+      /**
+       * The name of the log.
+       * @default "pino_log"
+       */
+      logName?: string;
+
+      /**
+       * The MonitoringResource to send logs to.
+       * @default { type: "global" }
+       */
+      resource?: {
+        type: string;
+        labels?: Record<string, string>;
+      }
+    }
+
+    /**
+     * Create a writestream that `pino-multi-stream` can use to send logs to.
+     * @param options
+     */
+    export const createWriteStream = (options: Options) => NodeJS.WritableStream;
+  }
+
+  export = PinoStackdriver;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 const stackdriver = require('./stackdriver')
 const pumpify = require('pumpify')
 
-module.exports.createWriteStream = ({ credentials, logName, projectId }) => {
+module.exports.createWriteStream = ({ credentials, logName, projectId, resource }) => {
   const parseJsonStream = stackdriver.parseJsonStream()
-  const toLogEntryStream = stackdriver.toLogEntryStream()
+  const toLogEntryStream = stackdriver.toLogEntryStream({ resource })
   const toStackdriverStream = stackdriver.toStackdriverStream({ credentials, logName, projectId })
   return pumpify(parseJsonStream, toLogEntryStream, toStackdriverStream)
 }

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -28,7 +28,7 @@ module.exports.parseJsonStream = function () {
 }
 
 module.exports.toLogEntry = function (log, options = {}) {
-  const { labels, prefix } = options
+  const { labels, prefix, resource } = options
 
   const severity = _levelToSeverity(log.level)
   let message = log.msg || severity
@@ -42,7 +42,7 @@ module.exports.toLogEntry = function (log, options = {}) {
 
   let entry = {
     meta: {
-      resource: { type: 'global' },
+      resource: resource || { type: 'global' },
       severity
     },
     data

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -97,7 +97,7 @@ test('adds httpRequest to log entry message', t => {
 })
 
 test('transforms log to entry in stream', t => {
-  t.plan(2)
+  t.plan(3)
 
   const parseJsonStream = tested.parseJsonStream()
   const toLogEntryStream = tested.toLogEntryStream()
@@ -105,6 +105,25 @@ test('transforms log to entry in stream', t => {
     if (err) { t.fail(err.message) }
     t.ok(result.length === 1)
     t.ok(result[0].meta.severity === 'info')
+    t.deepEquals(result[0].meta.resource, { type: 'global' })
+  })
+  const entry = { 'level': 30, 'time': 1532081790743, 'msg': 'info message', 'pid': 9118, 'hostname': 'Osmonds-MacBook-Pro.local', 'v': 1 }
+  const input = `${JSON.stringify(entry)}\n`
+  const readStream = helpers.readStreamTest([input])
+  readStream.pipe(writeStream)
+})
+
+test('transforms log to entry with custom resource in stream', t => {
+  t.plan(3)
+
+  const resource = { type: 'test', labels: { test: 'test' } }
+  const parseJsonStream = tested.parseJsonStream()
+  const toLogEntryStream = tested.toLogEntryStream({ resource })
+  const writeStream = helpers.transformStreamTest([parseJsonStream, toLogEntryStream], (err, result) => {
+    if (err) { t.fail(err.message) }
+    t.ok(result.length === 1)
+    t.ok(result[0].meta.severity === 'info')
+    t.deepEquals(result[0].meta.resource, { type: 'test', labels: { test: 'test' } })
   })
   const entry = { 'level': 30, 'time': 1532081790743, 'msg': 'info message', 'pid': 9118, 'hostname': 'Osmonds-MacBook-Pro.local', 'v': 1 }
   const input = `${JSON.stringify(entry)}\n`


### PR DESCRIPTION
This PR adds a `resource` option to the JS API. The resource option will allow you to specify where the logs will end up in Stackdriver Logging. Documentation for the value of the option can be found here: https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource.

I've taken the liberty to also improve and amend the documentation and add TypeScript types.