### PR TITLE
TypeScript improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -393,9 +393,9 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "11.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.2.tgz",
-      "integrity": "sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg=="
+      "version": "11.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.2.tgz",
+      "integrity": "sha512-HOtU5KqROKT7qX/itKHuTtt5fV0iXbheQvrgbLNXFJQBY/eh+VS5vmmTAVlo3qIGMsypm0G4N1t2AXjy1ZicaQ=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -812,7 +812,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -911,7 +911,7 @@
     },
     "d64": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
       "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
     "dashdash": {
@@ -1558,7 +1558,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "http://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -4050,7 +4050,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -5213,7 +5213,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5295,7 +5295,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -5322,7 +5322,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5378,7 +5378,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",
@@ -5410,7 +5410,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@google-cloud/logging": "^4.5.1",
+    "@types/node": "*",
     "commander": "^2.19.0",
     "fast-json-parse": "^1.0.3",
     "pumpify": "^1.5.1",

--- a/pino-stackdriver.d.ts
+++ b/pino-stackdriver.d.ts
@@ -1,39 +1,38 @@
-declare module "pino-stackdriver" {
-  namespace PinoStackdriver {
-    interface Options {
-      /**
-       * Full path to the JSON file containing the Google Service Credentials.
-       * Required if GOOGLE_APPLICATION_CREDENTIALS is not set as an environment variable.
-       */
-      credentials?: string;
-
-      /**
-       * The name of the project.
-       */
-      projectId: string;
-
-      /**
-       * The name of the log.
-       * @default "pino_log"
-       */
-      logName?: string;
-
-      /**
-       * The MonitoringResource to send logs to.
-       * @default { type: "global" }
-       */
-      resource?: {
-        type: string;
-        labels?: Record<string, string>;
-      }
-    }
+/// <reference types="node" />
+declare namespace PinoStackdriver {
+  export interface Options {
+    /**
+     * Full path to the JSON file containing the Google Service Credentials.
+     * Required if GOOGLE_APPLICATION_CREDENTIALS is not set as an environment variable.
+     */
+    credentials?: string;
 
     /**
-     * Create a writestream that `pino-multi-stream` can use to send logs to.
-     * @param options
+     * The name of the project.
      */
-    export const createWriteStream = (options: Options) => NodeJS.WritableStream;
+    projectId: string;
+
+    /**
+     * The name of the log.
+     * @default "pino_log"
+     */
+    logName?: string;
+
+    /**
+     * The MonitoringResource to send logs to.
+     * @default { type: "global" }
+     */
+    resource?: {
+      type: string;
+      labels?: Record<string, string>;
+    }
   }
 
-  export = PinoStackdriver;
+  /**
+   * Create a writestream that `pino-multi-stream` can use to send logs to.
+   * @param options
+   */
+  export const createWriteStream: (options: Options) => NodeJS.WritableStream;
 }
+
+export = PinoStackdriver


### PR DESCRIPTION
I've improved on my previously created TypeScript types. The `@types/node` dependency is needed because `createWriteStream()` returns a `NodeJS.WritableStream`.

- Remove unneeded .d.ts module declaration
- Fix bad createWriteStream type
- Add @types/node as a dependency