### PR TITLE
Make credentials optional

### DIFF
--- a/pino-stackdriver.d.ts
+++ b/pino-stackdriver.d.ts
@@ -3,7 +3,7 @@ declare namespace PinoStackdriver {
   export interface Options {
     /**
      * Full path to the JSON file containing the Google Service Credentials.
-     * Required if GOOGLE_APPLICATION_CREDENTIALS is not set as an environment variable.
+     * Defaults to GOOGLE_APPLICATION_CREDENTIALS environment variable.
      */
     credentials?: string;
 

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -67,7 +67,9 @@ module.exports.toLogEntryStream = function (options = {}) {
 
 module.exports.toStackdriverStream = function (options = {}) {
   const { logName, projectId, credentials } = options
-  process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials) {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials
+  }
   if (!projectId) { throw Error('The "projectId" argument is missing') }
   const opt = {
     logName: logName || 'pino_log',

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -67,7 +67,6 @@ module.exports.toLogEntryStream = function (options = {}) {
 
 module.exports.toStackdriverStream = function (options = {}) {
   const { logName, projectId, credentials } = options
-  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && !credentials) { throw Error('The "credentials" argument is missing') }
   process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials
   if (!projectId) { throw Error('The "projectId" argument is missing') }
   const opt = {

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -146,16 +146,16 @@ test('logs to stackdriver', t => {
   readStream.pipe(writeStream)
 })
 
-test('throws on missing credentials', t => {
+test('works without passing credentials', t => {
   t.plan(1)
 
   const { projectId } = helpers
   try {
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS
     tested.toStackdriverStream({ projectId })
-    t.fail('Should throw on missing credentials')
-  } catch (err) {
     t.ok(true)
+  } catch (err) {
+    t.fail('Should not have thrown')
   }
 })
 


### PR DESCRIPTION
Credentials for stackdriver logging are not required in every environment. App Engine, for instance, does not require them: https://cloud.google.com/logging/docs/setup/nodejs#run-gae. This PR makes them optional.

When running the application without credentials in an environment that does require them, the Google cloud logging library will throw an error anyway.