### PR TITLE
Take `message` field of log if `msg` is absent

### DIFF
--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -31,7 +31,7 @@ module.exports.toLogEntry = function (log, options = {}) {
   const { labels, prefix, resource } = options
 
   const severity = _levelToSeverity(log.level)
-  let message = log.msg || severity
+  let message = log.msg || log.message || severity
   message = (log.level >= PINO_LEVELS.error && log.stack) ? `${message}\n${log.stack}` : message
   message = (prefix) ? `[${prefix}] ${message}` : message
 

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -181,3 +181,11 @@ test('throws on missing options', t => {
     t.ok(true)
   }
 })
+
+test('transforms log entry message field', t => {
+  t.plan(1)
+
+  const log = { level: 35, time: parseInt('1532081790735', 10), message: 'Message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const entry = tested.toLogEntry(log)
+  t.ok(entry.data.message === 'Message')
+})


### PR DESCRIPTION
Provides backward compatibility with banyan
https://github.com/googleapis/nodejs-logging-bunyan/blob/ca01e8f7c6e24dc51f25ed3346f8d78880c22573/src/index.ts#L204
Log's `message` field was ignored in favor `severity`