### PR TITLE
add support for custom http request key, trace

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -31,7 +31,7 @@ const writeStream = stackdriver.createWriteStream({
   credentials: '/credentials.json',
   projectId: 'my-project'
 })
-````
+```
 
 #### credentials
 
@@ -56,3 +56,10 @@ The name of the log. Defaults to `"pino_log"`.
 Type: `{ type: String, labels: Object }` *(optional)*
 
 The resource to send logs to. Defaults to `{ type: "global" }`.
+
+#### keys
+
+Type: `{ [key]: key }` *(optional)*
+
+Customize additional fields to pull from log messages and include in meta. Currently
+supports `httpRequest`, `trace`. Defaults to `{ httpRequest: "httpRequest" }`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -23,6 +23,7 @@ You can pass the following options via cli arguments:
 | -V | --version | Output the version number |
 | -p | --project &lt;project&gt; | Your Google Cloud Platform project ID (or use env var PROJECT_ID) |
 | -c | --credentials &lt;credentials&gt; | The file path of the JSON file that contains your service account key (or use env var GOOGLE_APPLICATION_CREDENTIALS) |
+| -k | --key &lt;key:customKey&gt; | Repeatable `key:customKey` pairs for custom keys (see [API docs](./CLI.md#keys))
 | -h | --help | Output usage information |
 
 See the [API](./API.md) documentation for details.

--- a/pino-stackdriver.d.ts
+++ b/pino-stackdriver.d.ts
@@ -25,7 +25,16 @@ declare namespace PinoStackdriver {
     resource?: {
       type: string;
       labels?: Record<string, string>;
-    }
+    };
+
+    /**
+     * Names of log fields to pull properties out of - see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+     * @default { httpRequest: "httpRequest", trace: "trace", ... }
+     */
+    keys?: {
+      httpRequest?: string;
+      trace?: string;
+    };
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 const stackdriver = require('./stackdriver')
 const pumpify = require('pumpify')
 
-module.exports.createWriteStream = ({ credentials, logName, projectId, resource }) => {
+module.exports.createWriteStream = ({
+  credentials,
+  logName,
+  projectId,
+  resource,
+  keys
+}) => {
   const parseJsonStream = stackdriver.parseJsonStream()
-  const toLogEntryStream = stackdriver.toLogEntryStream({ resource })
+  const toLogEntryStream = stackdriver.toLogEntryStream({ resource, keys })
   const toStackdriverStream = stackdriver.toStackdriverStream({ credentials, logName, projectId })
   return pumpify(parseJsonStream, toLogEntryStream, toStackdriverStream)
 }

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -25,11 +25,15 @@ function _levelToSeverity (level) {
 
 const defaultKeys = {
   httpRequest: 'httpRequest',
-  trace: 'trace'
+  trace: undefined
 }
 
 function _getKey (log, data, k, keys) {
+  // use custom key, otherwise use default keys
   const key = (keys && keys[k]) ? keys[k] : defaultKeys[k]
+  // if no key is specified, return nothing
+  if (!key) return undefined
+  // if a value is defined, remove it from the log message to avoid double-loggin
   const v = log[key]
   if (v) {
     delete data[key]

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -29,7 +29,7 @@ const defaultKeys = {
 }
 
 function _getKey (log, data, k, keys) {
-  const key = keys && keys[k] ? keys[k] : defaultKeys[k]
+  const key = (keys && keys[k]) ? keys[k] : defaultKeys[k]
   const v = log[key]
   if (v) {
     delete data[key]

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -48,6 +48,18 @@ test('throws on missing project', (t) => {
   })
 })
 
+test('parses custom keys', (t) => {
+  t.plan(1)
+  delete process.env.PROJECT_ID
+  const app = spawn('node', [appPath, '-p', 'project-id', '--key', 'httpRequest:req', '--key', 'trace:trace'])
+  app.stdout.on('data', (data) => {
+    const msg = data.toString()
+    const res = (msg.indexOf('logging') >= 0)
+    t.ok(res)
+    app.kill()
+  })
+})
+
 test('picks up environment variables', (t) => {
   t.plan(1)
   process.env.GOOGLE_APPLICATION_CREDENTIALS = './credentials.json'

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -60,6 +60,17 @@ test('parses custom keys', (t) => {
   })
 })
 
+test('throws on invalid key', (t) => {
+  t.plan(1)
+  delete process.env.PROJECT_ID
+  const app = spawn('node', [appPath, '-p', 'project-id', '--key', 'httpRequest'])
+  app.stdout.on('data', (data) => {
+    const msg = data.toString()
+    const res = (msg.indexOf('Invalid key:customKey pair') >= 0)
+    t.ok(res)
+  })
+})
+
 test('picks up environment variables', (t) => {
   t.plan(1)
   process.env.GOOGLE_APPLICATION_CREDENTIALS = './credentials.json'

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -96,6 +96,24 @@ test('adds httpRequest to log entry message', t => {
   t.ok(entry.meta.httpRequest.url === 'http://localhost/')
 })
 
+test('adds httpRequest with custom key to log entry message', t => {
+  t.plan(2)
+
+  const log = { level: 30, time: parseInt('1532081790730', 10), req: { url: 'http://localhost/' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const entry = tested.toLogEntry(log, { keys: { httpRequest: 'req' } })
+  t.ok(entry.meta.severity === 'info')
+  t.ok(entry.meta.httpRequest.url === 'http://localhost/')
+})
+
+test('adds trace to log entry message', t => {
+  t.plan(2)
+
+  const log = { level: 30, time: parseInt('1532081790730', 10), trace: 'my/trace/id', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const entry = tested.toLogEntry(log)
+  t.ok(entry.meta.severity === 'info')
+  t.ok(entry.meta.trace === 'my/trace/id')
+})
+
 test('transforms log to entry in stream', t => {
   t.plan(3)
 

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -88,12 +88,15 @@ test('adds labels to log entry message', t => {
 })
 
 test('adds httpRequest to log entry message', t => {
-  t.plan(2)
+  t.plan(3)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), httpRequest: { url: 'http://localhost/' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = { level: 30, time: parseInt('1532081790730', 10), httpRequest: { url: 'http://localhost/' }, trace: 'my/trace/id', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
   const entry = tested.toLogEntry(log)
   t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.httpRequest.url === 'http://localhost/')
+
+  // by default, do not include trace
+  t.ok(entry.meta.trace === undefined)
 })
 
 test('adds httpRequest with custom key to log entry message', t => {
@@ -105,13 +108,23 @@ test('adds httpRequest with custom key to log entry message', t => {
   t.ok(entry.meta.httpRequest.url === 'http://localhost/')
 })
 
-test('adds trace to log entry message', t => {
+test('does not add trace to log entry message by default', t => {
   t.plan(2)
 
   const log = { level: 30, time: parseInt('1532081790730', 10), trace: 'my/trace/id', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
   const entry = tested.toLogEntry(log)
   t.ok(entry.meta.severity === 'info')
+  t.ok(entry.meta.trace === undefined)
+})
+
+test('adds trace to log entry message with option', t => {
+  t.plan(3)
+
+  const log = { level: 30, time: parseInt('1532081790730', 10), trace: 'my/trace/id', httpRequest: { url: 'http://localhost/' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const entry = tested.toLogEntry(log, { keys: { trace: 'trace' } })
+  t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.trace === 'my/trace/id')
+  t.ok(entry.meta.httpRequest.url === 'http://localhost/')
 })
 
 test('transforms log to entry in stream', t => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

This PR adds a `keys` option to provide custom keys programatically, and as part of the change allows users to set `trace`

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
