### PR TITLE
Add all api options to the cli

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -23,7 +23,9 @@ You can pass the following options via cli arguments:
 | -V | --version | Output the version number |
 | -p | --project &lt;project&gt; | Your Google Cloud Platform project ID (or use env var PROJECT_ID) |
 | -c | --credentials &lt;credentials&gt; | The file path of the JSON file that contains your service account key (or use env var GOOGLE_APPLICATION_CREDENTIALS) |
-| -k | --key &lt;key:customKey&gt; | Repeatable `key:customKey` pairs for custom keys (see [API docs](./CLI.md#keys))
+| -k | --key &lt;key:customKey&gt; | Repeatable `key:customKey` pairs for custom keys (see [API docs](./API.md#keys))
+| -n | --logName | The resource to send logs to. Defaults to `{"type": "global"}`.
+| -r | --resource &lt;resourcejson&gt; | Resource to send the logs to, input in JSON (see [API docs](./API.md#resource))
 | -h | --help | Output usage information |
 
 See the [API](./API.md) documentation for details.

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,9 @@ function main () {
     .option('-c, --credentials <credentials>', 'The file path of the JSON file that contains your service account key')
     .option('-p, --project <project>', 'Your Google Cloud Platform project ID')
     .option('-k, --key <key:customKey>', 'Customize additional data to include in log metadata', collect, [])
-    .action(({ credentials, project, key }) => {
+    .option('-n, --logName <name>', 'The name of the log. Defaults to "pino_log".')
+    .option('-r, --resource <resource>', 'The resource to send logs to. Defaults to { "type": "global" }', JSON.parse, { type: 'global' })
+    .action(({ credentials, project, key, logName, resource }) => {
       try {
         const _credentials = credentials || process.env.GOOGLE_APPLICATION_CREDENTIALS
         if (!process.env.PROJECT_ID && !project) { throw Error('Project is missing.') }
@@ -29,7 +31,7 @@ function main () {
           customKeys[pair[0]] = pair[1]
         })
 
-        const writeStream = stackdriver.createWriteStream({ credentials: _credentials, projectId: _project, keys: customKeys })
+        const writeStream = stackdriver.createWriteStream({ credentials: _credentials, projectId: _project, keys: customKeys, logName, resource })
         process.stdin.pipe(writeStream)
         console.info('logging')
       } catch (error) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -71,6 +71,18 @@ test('throws on invalid key', (t) => {
   })
 })
 
+test('parses resource', (t) => {
+  t.plan(1)
+  delete process.env.PROJECT_ID
+  const app = spawn('node', [appPath, '-p', 'project-id', '--key', 'httpRequest:req', '--resource', '{"type": "resourceTypeTest"}'])
+  app.stdout.on('data', (data) => {
+    const msg = data.toString()
+    const res = (msg.indexOf('logging') >= 0)
+    t.ok(res)
+    app.kill()
+  })
+})
+
 test('picks up environment variables', (t) => {
   t.plan(1)
   process.env.GOOGLE_APPLICATION_CREDENTIALS = './credentials.json'


### PR DESCRIPTION
I added the api options to the cli. Fixes #63 

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
