### PR TITLE
add fallback option for Google Logging API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -63,3 +63,9 @@ Type: `{ [key]: key }` *(optional)*
 
 Customize additional fields to pull from log messages and include in meta. Currently
 supports `httpRequest`, `trace`. Defaults to `{ httpRequest: "httpRequest" }`.
+
+#### fallback
+
+Type: Boolean *(optional)*
+
+Set the gRPC fallback option for the Google Stackdriver API.

--- a/pino-stackdriver.d.ts
+++ b/pino-stackdriver.d.ts
@@ -35,6 +35,11 @@ declare namespace PinoStackdriver {
       httpRequest?: string;
       trace?: string;
     };
+
+    /**
+     * Set the gRPC fallback option for the Google Stackdriver API.
+     */
+    fallback?: boolean;
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,12 @@ module.exports.createWriteStream = ({
   credentials,
   logName,
   projectId,
+  fallback,
   resource,
   keys
 }) => {
   const parseJsonStream = stackdriver.parseJsonStream()
   const toLogEntryStream = stackdriver.toLogEntryStream({ resource, keys })
-  const toStackdriverStream = stackdriver.toStackdriverStream({ credentials, logName, projectId })
+  const toStackdriverStream = stackdriver.toStackdriverStream({ credentials, logName, projectId, fallback })
   return pumpify(parseJsonStream, toLogEntryStream, toStackdriverStream)
 }

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -85,7 +85,7 @@ module.exports.toLogEntryStream = function (options = {}) {
 }
 
 module.exports.toStackdriverStream = function (options = {}) {
-  const { logName, projectId, credentials } = options
+  const { logName, projectId, credentials, fallback } = options
   if (process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials) {
     process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials
   }
@@ -93,7 +93,8 @@ module.exports.toStackdriverStream = function (options = {}) {
   const opt = {
     logName: logName || 'pino_log',
     projectId,
-    scopes: ['https://www.googleapis.com/auth/logging.write']
+    scopes: ['https://www.googleapis.com/auth/logging.write'],
+    fallback
   }
   const log = new Logging(opt).log(opt.logName)
   const writableStream = new stream.Writable({

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,6 +8,7 @@ const { Logging } = require('@google-cloud/logging')
 
 module.exports.credentials = '/credentials.json'
 module.exports.projectId = 'test-project'
+module.exports.fallback = true
 module.exports.package = pkg
 
 module.exports.stubLogging = () => {

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -190,6 +190,19 @@ test('works without passing credentials', t => {
   }
 })
 
+test('works with the fallback option', t => {
+  t.plan(1)
+
+  const { projectId, fallback } = helpers
+  try {
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+    tested.toStackdriverStream({ projectId, fallback })
+    t.ok(true)
+  } catch (err) {
+    t.fail('Should not have thrown')
+  }
+})
+
 test('throws on missing projectId', t => {
   t.plan(1)
 


### PR DESCRIPTION
Allow passing the fallback option for the gRPC calls, which should enable
bundling the library with Webpack.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
