### PR TITLE
Support passing credentials object parameter to Stackdriver

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,9 +35,11 @@ const writeStream = stackdriver.createWriteStream({
 
 #### credentials
 
-Type: `String` *(optional)*
+Type: `String` or `{ client_email: String, private_key: String }` *(optional)*
 
-Full path to the JSON file containing the Google Service Credentials. Defaults to the GOOGLE_APPLICATION_CREDENTIALS environment variable. At least one has to be available.
+Full path to the JSON file containing the Google Service Credentials, 
+you can also use an object parameter with the client_id and the private_key instead of the path. Defaults to the GOOGLE_APPLICATION_CREDENTIALS environment variable. At least one has to be available.
+
 
 #### projectId
 

--- a/pino-stackdriver.d.ts
+++ b/pino-stackdriver.d.ts
@@ -5,7 +5,7 @@ declare namespace PinoStackdriver {
      * Full path to the JSON file containing the Google Service Credentials.
      * Defaults to GOOGLE_APPLICATION_CREDENTIALS environment variable.
      */
-    credentials?: string;
+    credentials?: string | {client_email: string, private_key:string};
 
     /**
      * The name of the project.

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -86,9 +86,6 @@ module.exports.toLogEntryStream = function (options = {}) {
 
 module.exports.toStackdriverStream = function (options = {}) {
   const { logName, projectId, credentials, fallback } = options
-  if (process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials) {
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials
-  }
   if (!projectId) { throw Error('The "projectId" argument is missing') }
   const opt = {
     logName: logName || 'pino_log',
@@ -96,6 +93,15 @@ module.exports.toStackdriverStream = function (options = {}) {
     scopes: ['https://www.googleapis.com/auth/logging.write'],
     fallback
   }
+
+  if (typeof credentials === 'object' && credentials !== null) {
+    opt.credentials = credentials
+  } else {
+    if (process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials) {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_APPLICATION_CREDENTIALS || credentials
+    }
+  }
+
   const log = new Logging(opt).log(opt.logName)
   const writableStream = new stream.Writable({
     objectMode: true,

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -4,45 +4,99 @@ const test = require('tap').test
 const helpers = require('./helpers')
 const tested = require('../src/stackdriver')
 
-test('parses pino message in stream', t => {
+test('parses pino message in stream', (t) => {
   t.plan(2)
 
   const parseJsonStream = tested.parseJsonStream()
-  const writeStream = helpers.transformStreamTest(parseJsonStream, (err, result) => {
-    if (err) { t.fail(err.message) }
-    t.ok(result.length === 1)
-    t.ok(result[0].level === 30)
-  })
+  const writeStream = helpers.transformStreamTest(
+    parseJsonStream,
+    (err, result) => {
+      if (err) {
+        t.fail(err.message)
+      }
+      t.ok(result.length === 1)
+      t.ok(result[0].level === 30)
+    }
+  )
 
   const logger = pinoms({ streams: [writeStream] })
   logger.info('Informational message')
   writeStream.end()
 })
 
-test('does not parse invalid json in stream', t => {
+test('does not parse invalid json in stream', (t) => {
   t.plan(1)
 
   const parseJsonStream = tested.parseJsonStream()
-  const writeStream = helpers.transformStreamTest(parseJsonStream, (err, result) => {
-    if (err) { t.fail(err.message) }
-    t.ok(result.length === 0)
-  })
+  const writeStream = helpers.transformStreamTest(
+    parseJsonStream,
+    (err, result) => {
+      if (err) {
+        t.fail(err.message)
+      }
+      t.ok(result.length === 0)
+    }
+  )
   const readStream = helpers.readStreamTest(['invalid json'])
   readStream.pipe(writeStream)
 })
 
-test('transforms default log entry levels', t => {
+test('transforms default log entry levels', (t) => {
   t.plan(6)
 
   const logs = [
-    { level: 10, time: parseInt('1532081790710', 10), msg: 'trace message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 },
-    { level: 20, time: parseInt('1532081790720', 10), msg: 'debug message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 },
-    { level: 30, time: parseInt('1532081790730', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 },
-    { level: 40, time: parseInt('1532081790740', 10), msg: 'warning message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 },
-    { level: 50, time: parseInt('1532081790750', 10), msg: 'error message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', type: 'Error', stack: 'Error: error message', v: 1 },
-    { level: 60, time: parseInt('1532081790760', 10), msg: 'fatal message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+    {
+      level: 10,
+      time: parseInt('1532081790710', 10),
+      msg: 'trace message',
+      pid: 9118,
+      hostname: 'Osmonds-MacBook-Pro.local',
+      v: 1
+    },
+    {
+      level: 20,
+      time: parseInt('1532081790720', 10),
+      msg: 'debug message',
+      pid: 9118,
+      hostname: 'Osmonds-MacBook-Pro.local',
+      v: 1
+    },
+    {
+      level: 30,
+      time: parseInt('1532081790730', 10),
+      msg: 'info message',
+      pid: 9118,
+      hostname: 'Osmonds-MacBook-Pro.local',
+      v: 1
+    },
+    {
+      level: 40,
+      time: parseInt('1532081790740', 10),
+      msg: 'warning message',
+      pid: 9118,
+      hostname: 'Osmonds-MacBook-Pro.local',
+      v: 1
+    },
+    {
+      level: 50,
+      time: parseInt('1532081790750', 10),
+      msg: 'error message',
+      pid: 9118,
+      hostname: 'Osmonds-MacBook-Pro.local',
+      type: 'Error',
+      stack: 'Error: error message',
+      v: 1
+    },
+    {
+      level: 60,
+      time: parseInt('1532081790760', 10),
+      msg: 'fatal message',
+      pid: 9118,
+      hostname: 'Osmonds-MacBook-Pro.local',
+      v: 1
+    }
   ]
-  const entries = logs.map(log => {
+  const entries = logs.map((log) => {
     return tested.toLogEntry(log)
   })
   t.ok(entries[0].meta.severity === 'debug')
@@ -53,44 +107,87 @@ test('transforms default log entry levels', t => {
   t.ok(entries[5].meta.severity === 'critical')
 })
 
-test('transforms custom log entry level', t => {
+test('transforms custom log entry level', (t) => {
   t.plan(1)
 
-  const log = { level: 35, time: parseInt('1532081790735', 10), msg: 'custom level message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 35,
+    time: parseInt('1532081790735', 10),
+    msg: 'custom level message',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log)
   t.ok(entry.meta.severity === 'default')
 })
 
-test('prefixes log entry message', t => {
+test('prefixes log entry message', (t) => {
   t.plan(1)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    msg: 'info message',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log, { prefix: 'INFO' })
   t.ok(entry.data.message.startsWith('[INFO] '))
 })
 
-test('adds labels to log entry message', t => {
+test('adds labels to log entry message', (t) => {
   t.plan(5)
 
-  let log = { level: 30, time: parseInt('1532081790730', 10), labels: { foo: 'bar' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  let log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    labels: { foo: 'bar' },
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   let entry = tested.toLogEntry(log, { labels: { a: 'b' } })
   t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.labels.a === 'b')
   t.ok(entry.meta.labels.foo === 'bar')
 
-  log = { level: 30, time: parseInt('1532081790730', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    msg: 'info message',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   entry = tested.toLogEntry(log, { labels: { a: 'b' } })
   t.ok(entry.meta.severity === 'info')
 
-  log = { level: 30, time: parseInt('1532081790730', 10), labels: { foo: 'bar' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    labels: { foo: 'bar' },
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   entry = tested.toLogEntry(log)
   t.ok(entry.meta.severity === 'info')
 })
 
-test('adds httpRequest to log entry message', t => {
+test('adds httpRequest to log entry message', (t) => {
   t.plan(3)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), httpRequest: { url: 'http://localhost/' }, trace: 'my/trace/id', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    httpRequest: { url: 'http://localhost/' },
+    trace: 'my/trace/id',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log)
   t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.httpRequest.url === 'http://localhost/')
@@ -99,85 +196,151 @@ test('adds httpRequest to log entry message', t => {
   t.ok(entry.meta.trace === undefined)
 })
 
-test('adds httpRequest with custom key to log entry message', t => {
+test('adds httpRequest with custom key to log entry message', (t) => {
   t.plan(2)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), req: { url: 'http://localhost/' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    req: { url: 'http://localhost/' },
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log, { keys: { httpRequest: 'req' } })
   t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.httpRequest.url === 'http://localhost/')
 })
 
-test('does not add trace to log entry message by default', t => {
+test('does not add trace to log entry message by default', (t) => {
   t.plan(2)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), trace: 'my/trace/id', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    trace: 'my/trace/id',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log)
   t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.trace === undefined)
 })
 
-test('adds trace to log entry message with option', t => {
+test('adds trace to log entry message with option', (t) => {
   t.plan(3)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), trace: 'my/trace/id', httpRequest: { url: 'http://localhost/' }, pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 30,
+    time: parseInt('1532081790730', 10),
+    trace: 'my/trace/id',
+    httpRequest: { url: 'http://localhost/' },
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log, { keys: { trace: 'trace' } })
   t.ok(entry.meta.severity === 'info')
   t.ok(entry.meta.trace === 'my/trace/id')
   t.ok(entry.meta.httpRequest.url === 'http://localhost/')
 })
 
-test('transforms log to entry in stream', t => {
+test('transforms log to entry in stream', (t) => {
   t.plan(3)
 
   const parseJsonStream = tested.parseJsonStream()
   const toLogEntryStream = tested.toLogEntryStream()
-  const writeStream = helpers.transformStreamTest([parseJsonStream, toLogEntryStream], (err, result) => {
-    if (err) { t.fail(err.message) }
-    t.ok(result.length === 1)
-    t.ok(result[0].meta.severity === 'info')
-    t.deepEquals(result[0].meta.resource, { type: 'global' })
-  })
-  const entry = { level: 30, time: parseInt('1532081790743', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const writeStream = helpers.transformStreamTest(
+    [parseJsonStream, toLogEntryStream],
+    (err, result) => {
+      if (err) {
+        t.fail(err.message)
+      }
+      t.ok(result.length === 1)
+      t.ok(result[0].meta.severity === 'info')
+      t.deepEquals(result[0].meta.resource, { type: 'global' })
+    }
+  )
+  const entry = {
+    level: 30,
+    time: parseInt('1532081790743', 10),
+    msg: 'info message',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const input = `${JSON.stringify(entry)}\n`
   const readStream = helpers.readStreamTest([input])
   readStream.pipe(writeStream)
 })
 
-test('transforms log to entry with custom resource in stream', t => {
+test('transforms log to entry with custom resource in stream', (t) => {
   t.plan(3)
 
   const resource = { type: 'test', labels: { test: 'test' } }
   const parseJsonStream = tested.parseJsonStream()
   const toLogEntryStream = tested.toLogEntryStream({ resource })
-  const writeStream = helpers.transformStreamTest([parseJsonStream, toLogEntryStream], (err, result) => {
-    if (err) { t.fail(err.message) }
-    t.ok(result.length === 1)
-    t.ok(result[0].meta.severity === 'info')
-    t.deepEquals(result[0].meta.resource, { type: 'test', labels: { test: 'test' } })
-  })
-  const entry = { level: 30, time: parseInt('1532081790743', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const writeStream = helpers.transformStreamTest(
+    [parseJsonStream, toLogEntryStream],
+    (err, result) => {
+      if (err) {
+        t.fail(err.message)
+      }
+      t.ok(result.length === 1)
+      t.ok(result[0].meta.severity === 'info')
+      t.deepEquals(result[0].meta.resource, {
+        type: 'test',
+        labels: { test: 'test' }
+      })
+    }
+  )
+  const entry = {
+    level: 30,
+    time: parseInt('1532081790743', 10),
+    msg: 'info message',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const input = `${JSON.stringify(entry)}\n`
   const readStream = helpers.readStreamTest([input])
   readStream.pipe(writeStream)
 })
 
-test('logs to stackdriver', t => {
+test('logs to stackdriver', (t) => {
   t.plan(1)
-  const sl = helpers.stubLogging()
-
   const { credentials, projectId } = helpers
+  const sl = helpers.stubLogging()
   const writeStream = tested.toStackdriverStream({ credentials, projectId })
+
   writeStream.on('finish', () => {
     t.ok(true)
     sl.restore()
+  })
+  const entry = {
+    meta: { resource: { type: 'global' }, severity: 'info' },
+    data: { message: 'Info message' }
+  }
+  const readStream = helpers.readStreamTest([entry])
+  readStream.pipe(writeStream)
+})
+
+test('logs to stackdriver with an object credentials', t => {
+  t.plan(1)
+  const credentials = { client_email: 'fakeEmail', private_key: 'fakeKey' }
+  const projectId = 'test-project'
+
+  const writeStream = tested.toStackdriverStream({ credentials, projectId })
+  writeStream.on('finish', () => {
+    t.ok(true)
   })
   const entry = { meta: { resource: { type: 'global' }, severity: 'info' }, data: { message: 'Info message' } }
   const readStream = helpers.readStreamTest([entry])
   readStream.pipe(writeStream)
 })
 
-test('works without passing credentials', t => {
+test('works without passing credentials', (t) => {
   t.plan(1)
 
   const { projectId } = helpers
@@ -190,7 +353,7 @@ test('works without passing credentials', t => {
   }
 })
 
-test('works with the fallback option', t => {
+test('works with the fallback option', (t) => {
   t.plan(1)
 
   const { projectId, fallback } = helpers
@@ -203,7 +366,7 @@ test('works with the fallback option', t => {
   }
 })
 
-test('throws on missing projectId', t => {
+test('throws on missing projectId', (t) => {
   t.plan(1)
 
   const { credentials } = helpers
@@ -215,7 +378,7 @@ test('throws on missing projectId', t => {
   }
 })
 
-test('throws on missing options', t => {
+test('throws on missing options', (t) => {
   t.plan(1)
 
   try {
@@ -226,10 +389,17 @@ test('throws on missing options', t => {
   }
 })
 
-test('transforms log entry message field', t => {
+test('transforms log entry message field', (t) => {
   t.plan(1)
 
-  const log = { level: 35, time: parseInt('1532081790735', 10), message: 'Message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
+  const log = {
+    level: 35,
+    time: parseInt('1532081790735', 10),
+    message: 'Message',
+    pid: 9118,
+    hostname: 'Osmonds-MacBook-Pro.local',
+    v: 1
+  }
   const entry = tested.toLogEntry(log)
   t.ok(entry.data.message === 'Message')
 })


### PR DESCRIPTION
Regarding this [enhancement](https://github.com/ovhemert/pino-stackdriver/issues/68), was added Support passing credentials object parameter to Stackdriver


#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
