### PR TITLE
fix: Use prefix from log

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@ const writeStream = stackdriver.createWriteStream({
 
 Type: `String` or `{ client_email: String, private_key: String }` *(optional)*
 
-Full path to the JSON file containing the Google Service Credentials, 
+Full path to the JSON file containing the Google Service Credentials,
 you can also use an object parameter with the client_email and the private_key instead of the path. Defaults to the GOOGLE_APPLICATION_CREDENTIALS environment variable. At least one has to be available.
 
 
@@ -71,3 +71,22 @@ supports `httpRequest`, `trace`. Defaults to `{ httpRequest: "httpRequest" }`.
 Type: Boolean *(optional)*
 
 Set the gRPC fallback option for the Google Stackdriver API.
+
+## Prefixing messages
+
+Prefixing message is supported via a `prefix` property from the log data:
+
+```js
+logger.info({ prefix: 'foo' }, 'Info message')
+logger.child({ prefix: 'foo' }).info('Info message')
+```
+
+Will send the following JSON payload to Stackdriver:
+
+```json
+{
+  "prefix": "foo",
+  "message": "[foo] Info message"
+  // ...
+}
+```

--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -47,7 +47,8 @@ module.exports.parseJsonStream = function () {
 }
 
 module.exports.toLogEntry = function (log, options = {}) {
-  const { labels, prefix, resource, keys } = options
+  const { labels, resource, keys } = options
+  const { prefix } = log
 
   const severity = _levelToSeverity(log.level)
   let message = log.msg || log.message || severity

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -64,8 +64,8 @@ test('transforms custom log entry level', t => {
 test('prefixes log entry message', t => {
   t.plan(1)
 
-  const log = { level: 30, time: parseInt('1532081790730', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', v: 1 }
-  const entry = tested.toLogEntry(log, { prefix: 'INFO' })
+  const log = { level: 30, time: parseInt('1532081790730', 10), msg: 'info message', pid: 9118, hostname: 'Osmonds-MacBook-Pro.local', prefix: 'INFO' }
+  const entry = tested.toLogEntry(log)
   t.ok(entry.data.message.startsWith('[INFO] '))
 })
 


### PR DESCRIPTION
I saw there is some code already to prefix the message before being sent to StackDriver stream. But it seems to be using a `prefix` from `options`, which never gets defined.

Instead I used the `prefix` property from `log`.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
