### PR TITLE
feat: Parse and log invalid JSON

### DIFF
--- a/src/stackdriver.js
+++ b/src/stackdriver.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const stream = require('stream')
 
 const fastJsonParse = require('fast-json-parse')
@@ -7,10 +8,19 @@ const { Logging } = require('@google-cloud/logging')
 
 const PINO_LEVELS = { trace: 10, debug: 20, info: 30, warn: 40, error: 50, fatal: 60 }
 // const STACKDRIVER_SEVERITIES = { default: 0, debug: 100, info: 200, notice: 300, warning: 400, error: 500, critical: 600, alert: 700, emergency: 800 }
+const HOSTNAME = os.hostname()
 
 function _jsonParser (str) {
   const result = fastJsonParse(str)
-  if (result.err) return
+  if (result.err) {
+    return {
+      hostname: HOSTNAME,
+      level: PINO_LEVELS.debug,
+      msg: str,
+      pid: process.pid,
+      time: Date.now()
+    }
+  }
   return result.value
 }
 

--- a/test/stackdriver.test.js
+++ b/test/stackdriver.test.js
@@ -19,13 +19,15 @@ test('parses pino message in stream', t => {
   writeStream.end()
 })
 
-test('does not parse invalid json in stream', t => {
-  t.plan(1)
+test('parses invalid json in stream', t => {
+  t.plan(3)
 
   const parseJsonStream = tested.parseJsonStream()
   const writeStream = helpers.transformStreamTest(parseJsonStream, (err, result) => {
     if (err) { t.fail(err.message) }
-    t.ok(result.length === 0)
+    t.ok(result.length === 1)
+    t.ok(result[0].level === 20)
+    t.ok(result[0].msg === 'invalid json')
   })
   const readStream = helpers.readStreamTest(['invalid json'])
   readStream.pipe(writeStream)


### PR DESCRIPTION
In a production app, there might be parts of the app that log useful debug data without using `pino`. It's useful to store these logs for later inspection.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
