### PR TITLE
Update supported node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/ovhemert/pino-stackdriver.git"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=12"
   },
   "precommit": [
     "lint",


### PR DESCRIPTION
Drop support for Node v10 and add v16.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
